### PR TITLE
Update go-ethereum (v1.10.20) and go (1.18) versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,19 @@
 module github.com/everFinance/goether
 
-go 1.15
+go 1.18
 
 require (
-	github.com/ethereum/go-ethereum v1.10.12
+	github.com/ethereum/go-ethereum v1.10.20
 	github.com/everFinance/ethrpc v1.0.4
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.2
+)
+
+require (
+	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/signer.go
+++ b/signer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/signer/core"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
 type Signer struct {
@@ -97,7 +97,7 @@ func (s Signer) SignMsg(msg []byte) (sig []byte, err error) {
 	return
 }
 
-func (s Signer) SignTypedData(typedData core.TypedData) (sig []byte, err error) {
+func (s Signer) SignTypedData(typedData apitypes.TypedData) (sig []byte, err error) {
 	hash, err := EIP712Hash(typedData)
 	if err != nil {
 		return

--- a/signer_test.go
+++ b/signer_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/signer/core"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +38,7 @@ func TestSignMsg(t *testing.T) {
 
 func TestSignTypedData(t *testing.T) {
 	typedDataJson := `{"primaryType":"Mail","types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}]},"domain":{"name":"Ether Mail","version":"1","chainId":1,"verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"},"message":{"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},"contents":"Hello, Bob!"}}`
-	var typedData core.TypedData
+	var typedData apitypes.TypedData
 	json.Unmarshal([]byte(typedDataJson), &typedData)
 	sig, err := TestSigner.SignTypedData(typedData)
 	assert.NoError(t, err)

--- a/utils.go
+++ b/utils.go
@@ -3,12 +3,12 @@ package goether
 import (
 	"crypto/rand"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/signer/core"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
 func EthToBN(amount float64) (bn *big.Int) {
@@ -23,7 +23,7 @@ func GweiToBN(amount float64) (bn *big.Int) {
 	return bn
 }
 
-func EIP712Hash(typedData core.TypedData) (hash []byte, err error) {
+func EIP712Hash(typedData apitypes.TypedData) (hash []byte, err error) {
 	domainSeparator, err := typedData.HashStruct("EIP712Domain", typedData.Domain.Map())
 	if err != nil {
 		return

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,14 +2,14 @@ package goether
 
 import (
 	"encoding/json"
-	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/signer/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +24,7 @@ func TestGweiToBN(t *testing.T) {
 func TestEIP712(t *testing.T) {
 	raw := `{"types": {"EIP712Domain": [{"name": "name","type": "string"},{"name": "version","type": "string"},{"name": "chainId","type": "uint256"}],"Order": [{"name": "action","type": "string"},{"name": "orderHashes","type": "string[]"},{"name": "makerAddress","type": "address"}]},"primaryType": "Order","domain": {"name": "ZooDex","version": "1","chainId": "42"},"message": {"action": "cancelOrder","orderHashes": ["0x123", "0x456", "0x789"],"makerAddress": "0xf9593A9d7F735814B87D08e8D8aD624f58d53B10"}}
 	`
-	typedData := core.TypedData{}
+	typedData := apitypes.TypedData{}
 	err := json.Unmarshal([]byte(raw), &typedData)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
### What happened?
I got error then using goar (v1.4.4) module with newest go-ethereum (v1.10.20) modules:
```
# github.com/everFinance/goether
HOME/go/pkg/mod/github.com/ever!finance/goether@v1.1.7/signer.go:100:46: undefined: core.TypedData
HOME/go/pkg/mod/github.com/ever!finance/goether@v1.1.7/utils.go:26:32: undefined: core.TypedData
```

### What I did.
- Update go-ethereum to newest version. They change package for TypedData type
- Update go to 1.18